### PR TITLE
Add method to remove all records about an app

### DIFF
--- a/include/core/trust/store.h
+++ b/include/core/trust/store.h
@@ -176,6 +176,11 @@ public:
     virtual void add(const Request& request) = 0;
 
     /**
+     * @brief Remove all requests issued by the given application.
+     */
+    virtual void remove_application(const std::string& id) = 0;
+
+    /**
      * @brief Create a query for this store.
      */
     virtual std::shared_ptr<Query> query() = 0;

--- a/src/core/trust/dbus/interface.h
+++ b/src/core/trust/dbus/interface.h
@@ -85,6 +85,20 @@ struct Store
             typedef core::trust::Store Interface;
         };
 
+        struct RemovingApplication
+        {
+            static const std::string& name()
+            {
+                static const std::string s
+                {
+                    "core.trust.store.error.RemovingApplication"
+                };
+
+                return s;
+            }
+            typedef core::trust::Store Interface;
+        };
+
         struct ResettingStore
         {
             static const std::string& name()
@@ -338,6 +352,26 @@ struct Store
         }
         typedef core::trust::Store Interface;
         typedef core::trust::Request ArgumentType;
+        typedef void ResultType;
+
+        inline static const std::chrono::milliseconds default_timeout()
+        {
+            return std::chrono::seconds{1};
+        }
+    };
+
+    struct RemoveApplication
+    {
+        inline static const std::string& name()
+        {
+            static const std::string& s
+            {
+                "RemoveApplication"
+            };
+            return s;
+        }
+        typedef core::trust::Store Interface;
+        typedef std::string ArgumentType;
         typedef void ResultType;
 
         inline static const std::chrono::milliseconds default_timeout()

--- a/src/core/trust/resolve.cpp
+++ b/src/core/trust/resolve.cpp
@@ -195,6 +195,17 @@ struct Store : public core::trust::Store
             throw std::runtime_error(response.error().print());
     }
 
+    void remove_application(const std::string& id)
+    {
+        auto response =
+                proxy->invoke_method_synchronously<
+                    core::trust::dbus::Store::RemoveApplication,
+                    void>(id);
+
+        if (response.is_error())
+            throw std::runtime_error(response.error().print());
+    }
+
     void reset()
     {
         try

--- a/tests/mock_store.h
+++ b/tests/mock_store.h
@@ -69,6 +69,10 @@ struct MockStore : public core::trust::Store
       */
     MOCK_METHOD1(add, void(const core::trust::Request&));
 
+    /** @brief Remove all records about the given application.
+      */
+    MOCK_METHOD1(remove_application, void(const std::string&));
+
     /**
      * @brief Create a query for this store.
      */


### PR DESCRIPTION
This is part of the fix for https://github.com/ubports/ubuntu-touch/issues/385, but it might not be needed after all.