### PR TITLE
mir/agent: fix indefinite wait if fail to start prompt session

### DIFF
--- a/src/core/trust/mir/agent.h
+++ b/src/core/trust/mir/agent.h
@@ -64,6 +64,9 @@ public:
     PromptSessionVirtualTable(MirPromptSession* prompt_session);
     virtual ~PromptSessionVirtualTable() = default;
 
+    // Retrieve a text description of the last error.
+    virtual std::string error_message();
+
     // Requests a new, pre-authenticated fd for associating prompt providers.
     // Returns the fd or throws std::runtime_error.
     virtual int new_fd_for_prompt_provider();


### PR DESCRIPTION
For some reason, Mir still provide an FD for a prompt session even if it
fails to start. When this FD is passed to the prompt provider, it will
just hang, causing the whole trust store user chain to just wait. To fix
this, make sure the agent checks for the error before continue.

Related: https://github.com/ubports/ubuntu-touch/issues/1668